### PR TITLE
Compiler settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Using [vim-plug](https://github.com/junegunn/vim-plug):
 ```
 Plug 'teal-language/vim-teal'
 ```
-For linter and `:compiler` support, you also need to install [ALE](https://github.com/dense-analysis/ale). Also, you have to make sure that [`tl` is installed and available in the PATH.](https://github.com/teal-language/tl#installing)
+
+For `:compiler` support, make sure you have [`tl` in your PATH](https://github.com/teal-language/tl#installing).
+For linter and support, you also need to install [ALE](https://github.com/dense-analysis/ale) and have [`tl` in your PATH](https://github.com/teal-language/tl#installing).

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Using [vim-plug](https://github.com/junegunn/vim-plug):
 ```
 Plug 'teal-language/vim-teal'
 ```
-For linter support, you also need to install [ALE](https://github.com/dense-analysis/ale). Also, you have to make sure that [`tl` is installed and available in the PATH.](https://github.com/teal-language/tl#installing)
+For linter and `:compiler` support, you also need to install [ALE](https://github.com/dense-analysis/ale). Also, you have to make sure that [`tl` is installed and available in the PATH.](https://github.com/teal-language/tl#installing)

--- a/compiler/tl.vim
+++ b/compiler/tl.vim
@@ -1,0 +1,20 @@
+
+if exists("current_compiler")
+	finish
+endif
+let current_compiler = "tl"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+if exists("g:teal_check_only")
+	CompilerSet makeprg=tl\ check\ %
+elseif exists("g:teal_check_before_gen")
+	CompilerSet makeprg=tl\ check\ %\ &&\ tl\ gen\ %
+else
+	CompilerSet makeprg=tl\ gen\ %
+endif
+CompilerSet errorformat=%f:%l:%c:%m
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/compiler/tl.vim
+++ b/compiler/tl.vim
@@ -14,7 +14,7 @@ elseif exists("g:teal_check_before_gen")
 else
 	CompilerSet makeprg=tl\ gen\ %
 endif
-CompilerSet errorformat=%f:%l:%c:%m
+CompilerSet errorformat=%f:%l:%c:\ %m
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/teal.vim
+++ b/ftplugin/teal.vim
@@ -7,7 +7,7 @@ let s:cpo_save = &cpo
 
 setlocal comments=s:--[[,mb:-,ex:]],:--,f:#,:--
 setlocal commentstring=--%s
-setlocal makeprg=tl\ gen\ %
+
 if exists("loaded_matchit")
 	let b:match_ignorecase = 0
 	let b:match_words=


### PR DESCRIPTION
Set the makeprg with the bulit in :compiler command

Options: set these before running `:compiler tl` to modify behavior
- g:teal\_check\_only
- g:teal\_check\_before\_gen

Afterwards `:make` should run `tl gen`

The majority of the `:compiler` commands use the name of the compiler itself, so this being named `tl` is fine.