### PR TITLE
Syntax rework

### DIFF
--- a/indent/teal.vim
+++ b/indent/teal.vim
@@ -29,18 +29,9 @@ let s:block_close_patt = '\C^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\|)\)'
 
 let s:function_patt = '\C\<function\>'
 let s:record_patt = '\C\<record\>'
-let s:ignore_patt = 'tealString'
-	\ . '\|tealLongString' 
-	\ . '\|tealComment' 
-	\ . '\|tealLongComment' 
-	\ . '\|tealBasicType'
-	\ . '\|tealFunctionType'
-	\ . '\|tealFunctionTypeArgs'
-	\ . '\|tealParenTypes'
-	\ . '\|tealTableType'
-	\ . '\|tealGenericType'
-	\ . '\|tealVarName'
-	\ . '\|tealTypeAnnotation'
+let s:ignore_patt = 'tealString\|tealLongString' 
+	\ . '\|tealComment\|tealLongComment' 
+	\ . '\|Type$'
 
 let s:bin_op = "\\C\\([<>=~^&|*/\%+-.:]\\|or\\|and\\|is\\|as\\)"
 let s:starts_with_bin_op = "^[\t ]*" . s:bin_op 

--- a/indent/teal.vim
+++ b/indent/teal.vim
@@ -33,7 +33,7 @@ let s:ignore_patt = 'tealString\|tealLongString'
 	\ . '\|tealComment\|tealLongComment' 
 	\ . '\|Type$'
 
-let s:bin_op = "\\C\\([<>=~^&|*/\%+-.:]\\|or\\|and\\|is\\|as\\)"
+let s:bin_op = "\\C\\([<>=~^&|*/\%+-.:]\\|\\<or\\>\\|\\<and\\>\\|\\<is\\>\\|\\<as\\>\\)"
 let s:starts_with_bin_op = "^[\t ]*" . s:bin_op 
 let s:ends_with_bin_op = s:bin_op . "[\t ]*$"
 " }}}

--- a/indent/teal.vim
+++ b/indent/teal.vim
@@ -23,29 +23,25 @@ if exists("*GetTealIndent")
 endif
 " }}}
 " {{{ Patterns
-let s:begin_block_open_patt = '\C^\s*\%(if\>\|for\>\|while\>\|repeat\>\|else\>\|elseif\>\|do\>\|then\>\)'
-let s:end_block_open_patt = '\C\({\|(\|enum\>\|then\>\)\s*$'
-let s:block_close_patt = '\C^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\|)\)'
+" [\t ] seems to be faster than \s
+let s:begin_block_open_patt = '\C^[\t ]*\%(if\|for\|while\|repeat\|else\|elseif\|do\|then\)\>'
+let s:end_block_open_patt = '\C\%({\|enum\|then\)[\t ]*$'
+let s:block_close_patt = '\C^[\t ]*\%(\%(end\|else\|elseif\|until\)\>\|}\|)\)'
 
-let s:function_patt = '\C\<function\>'
-let s:record_patt = '\C\<record\>'
-let s:ignore_patt = 'tealString\|tealLongString' 
-	\ . '\|tealComment\|tealLongComment' 
-	\ . '\|Type$'
+let s:middle_patt = '\C\<\%(function\|record\)\>'
+let s:ignore_patt = 'String$\|Comment$\|Type$'
 
-let s:bin_op = "\\C\\([<>=~^&|*/\%+-.:]\\|\\<or\\>\\|\\<and\\>\\|\\<is\\>\\|\\<as\\>\\)"
-let s:starts_with_bin_op = "^[\t ]*" . s:bin_op 
-let s:ends_with_bin_op = s:bin_op . "[\t ]*$"
+let s:starts_with_bin_op = '\C^[\t ]*\([<>=~^&|*/%+-.:]\|\%(or\|and\|is\|as\)\>\)'
 " }}}
 " {{{ Helpers
-function s:IsInCommentOrString(line_num, column)
-	return synIDattr(synID(a:line_num, a:column, 1), 'name') =~# 'tealLongComment\|tealLongString'
-		\ && !(getline(a:line_number) =~# '^\s*\%(--\)\?\[=*\[')
+function s:IsIgnorable(line_num, column)
+	return synIDattr(synID(a:line_num, a:column, 1), 'name') =~# s:ignore_patt
+		\ && !(getline(a:line_number) =~# '^[\t ]*\%(--\)\?\[=*\[')
 endfunction
 
 function s:PrevLineOfCode(line_num)
 	let line_num = prevnonblank(a:line_num)
-	while s:IsInCommentOrString(line_num, 1)
+	while s:IsIgnorable(line_num, 1)
 		let line_num = prevnonblank(line_num - 1)
 	endwhile
 	return line_num
@@ -72,7 +68,7 @@ endfunction
 " }}}
 " {{{ The Indent function
 function GetTealIndent(lnum)
-	if s:IsInCommentOrString(a:lnum, 1)
+	if s:IsIgnorable(a:lnum, 1)
 		return indent(a:lnum - 1)
 	endif
 	let prev_line_num = s:PrevLineOfCode(a:lnum - 1)
@@ -85,11 +81,10 @@ function GetTealIndent(lnum)
 	let i = 0
 	let match_index = s:MatchPatt(prev_line_num, prev_line, s:begin_block_open_patt, -1)
 	let match_index = s:MatchPatt(prev_line_num, prev_line, s:end_block_open_patt, match_index)
-	let match_index = s:MatchPatt(prev_line_num, prev_line, s:function_patt, match_index)
-	let match_index = s:MatchPatt(prev_line_num, prev_line, s:record_patt, match_index)
+	let match_index = s:MatchPatt(prev_line_num, prev_line, s:middle_patt, match_index)
 
 	" If the previous line opens a block (and doesnt close it), >>
-	if match_index != -1 && prev_line !~# '\C\<end\>\|\<until\>'
+	if match_index != -1 && prev_line !~# '\C\<\%(end\|until\)\>'
 		let i += 1
 	endif
 
@@ -121,8 +116,8 @@ function GetTealIndent(lnum)
 
 	if i > 1
 		let i = 1
-	elseif i < -1
-		let i = -1
+	" elseif i < -1
+	" 	let i = -1
 	endif
 	return indent(prev_line_num) + (shiftwidth() * i)
 endfunction

--- a/indent/teal.vim
+++ b/indent/teal.vim
@@ -119,6 +119,11 @@ function GetTealIndent(lnum)
 		let i -= 1
 	endif
 
+	if i > 1
+		let i = 1
+	elseif i < -1
+		let i = -1
+	endif
 	return indent(prev_line_num) + (shiftwidth() * i)
 endfunction
 " }}}

--- a/syntax/teal.vim
+++ b/syntax/teal.vim
@@ -55,7 +55,7 @@ let s:typePatterns = {
 	\ 'tealFunctionType': {
 	\	'synType': 'match',
 	\	'patt': '\<function\>',
-	\	'nextgroup': ['tealFunctionGenericType,tealFunctionArgsType'],
+	\	'nextgroup': ['tealFunctionGenericType', 'tealFunctionArgsType'],
 	\ },
 	\ 'tealBasicType': {
 	\	'synType': 'match',
@@ -105,6 +105,9 @@ function s:ToSingleName(str)
 endfunction
 " }}}
 function s:MakeSyntaxItem(typeName, props)
+	if exists("a:props.contains")
+		let a:props.contains += ['tealLongComment']
+	endif
 	for single in [v:true, v:false]
 		let tname = a:typeName
 		if single
@@ -320,8 +323,8 @@ syn keyword tealConstant nil true false
 " {{{ Strings
 syn match tealSpecial contained #\\[\\abfnrtvz'"]\|\\x[[:xdigit:]]\{2}\|\\[[:digit:]]\{,3}#
 syn region tealLongString matchgroup=tealString start="\[\z(=*\)\[" end="\]\z1\]" contains=@Spell
-syn region tealString  start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=tealSpecial,@Spell
-syn region tealString  start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=tealSpecial,@Spell
+syn region tealString  start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=tealSpecial,@Spell oneline
+syn region tealString  start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=tealSpecial,@Spell oneline
 " }}}
 " {{{ Numbers
 " integer number

--- a/syntax/teal.vim
+++ b/syntax/teal.vim
@@ -3,6 +3,10 @@
 if exists("b:current_syntax")
 	finish
 endif
+if !has("lambda")
+	echoerr "vim-teal: Teal syntax requires lambda support, please update your vim installation"
+	finish
+endif
 
 let s:cpo_save = &cpo
 set cpo&vim
@@ -25,8 +29,9 @@ syn cluster tealStatement contains=
 	\ tealLocal,tealGlobal
 
 " {{{ ), ], end, etc error
-syntax match tealError "\()\|}\|\]\)"
-syntax match tealError "\<\%(end\|else\|elseif\|then\|until\|in\)\>"
+syn match tealError "\()\|}\|\]\)"
+syn match tealError "\<\%(end\|else\|elseif\|then\|until\|in\)\>"
+syn match tealInvalidIdentifier /\K\k*/ contained
 " }}}
 " {{{ Table Constructor
 syn region tealTableConstructor
@@ -211,7 +216,7 @@ syn match tealFunctionStart /\(\<function\>\)\@8<=\s*/ contained
 	\ nextgroup=tealFunctionName,tealFunctionGeneric,tealFunctionArgs
 	\ skipwhite skipempty skipnl
 syn match tealFunctionName /\K\k*\(\.\K\k*\)*\(:\K\k*\)\?/ contained
-	\ nextgroup=tealFunctionGeneric,tealFunctionArgs
+	\ nextgroup=tealFunctionGeneric,tealFunctionArgs,tealInvalidIdentifier
 	\ skipwhite skipempty skipnl
 syn region tealFunctionGeneric contained transparent
 	\ start=/</ end=/>/
@@ -477,6 +482,7 @@ hi def link tealNumber                Number
 hi def link tealOperator              Operator
 hi def link tealBuiltin               Identifier
 hi def link tealError                 Error
+hi def link tealInvalidIdentifier     Error
 hi def link tealGeneric               Type
 hi def link tealTodo                  Todo
 " }}}

--- a/syntax/teal.vim
+++ b/syntax/teal.vim
@@ -66,6 +66,7 @@ let s:typePatterns = {
 	\	'synType': 'region',
 	\	'start': '<',
 	\	'end': '>',
+	\	'matchgroup': 'tealParens',
 	\	'nextgroup': ['tealFunctionArgsType'],
 	\	'contains': ['tealGeneric'],
 	\ },
@@ -73,12 +74,14 @@ let s:typePatterns = {
 	\	'synType': 'region',
 	\	'start': '<',
 	\	'end': '>',
+	\	'matchgroup': 'tealParens',
 	\	'contains': ['tealGeneric'],
 	\ },
 	\ 'tealFunctionArgsType': {
 	\	'synType': 'region',
 	\	'start': '(',
 	\	'end': ')',
+	\	'matchgroup': 'tealParens',
 	\	'contains': ['@tealType'],
 	\	'nextgroup': ['tealTypeAnnotation']
 	\ },
@@ -96,11 +99,16 @@ let s:typePatterns = {
 " make a second syntax item with nextgroup=tealSingleUnion
 " the effect of this is that we have @tealType, which is a type list
 " and @tealSingleType for function arguments
+" {{{ ToSingleName
+function s:ToSingleName(str)
+	return a:str[:-5] . 'SingleType'
+endfunction
+" }}}
 function s:MakeSyntaxItem(typeName, props)
 	for single in [v:true, v:false]
 		let tname = a:typeName
 		if single
-			let tname .= 'Single'
+			let tname = s:ToSingleName(tname)
 		endif
 		let cmd = 'syntax '
 		let cmd .= a:props.synType
@@ -126,7 +134,7 @@ function s:MakeSyntaxItem(typeName, props)
 		else
 			let nextgroup = []
 		endif
-		call map(nextgroup, {-> single && v:val[-4:] == "Type" ? v:val . "Single" : v:val})
+		call map(nextgroup, {-> single && v:val[-4:] == "Type" ? s:ToSingleName(v:val) : v:val})
 		if single
 			let nextgroup += ['tealSingleUnion']
 		else
@@ -137,7 +145,7 @@ function s:MakeSyntaxItem(typeName, props)
 		exec cmd
 		exec "syn cluster teal" . (single ? "Single" : "") . "Type add=" . tname
 	endfor
-	exec "highlight link " . tname . "Single " . tname
+	exec "highlight link " . s:ToSingleName(tname) . " " . tname
 endfunction
 call map(s:typePatterns, {tname, props -> s:MakeSyntaxItem(tname, props)})
 

--- a/syntax/teal.vim
+++ b/syntax/teal.vim
@@ -206,8 +206,11 @@ syn region tealBracket transparent
 syn region tealFunctionBlock transparent
 	\ matchgroup=tealFunction
 	\ start=/\<function\>/ end=/\<end\>/
-	\ contains=@tealStatement,tealFunctionName
-syn match tealFunctionName /\(\<function\>\)\@8<=\s\+\K\k*\(\.\K\k*\)*\(:\K\k*\)\?/ contained
+	\ contains=@tealStatement,tealFunctionStart
+syn match tealFunctionStart /\(\<function\>\)\@8<=\s*/ contained
+	\ nextgroup=tealFunctionName,tealFunctionGeneric,tealFunctionArgs
+	\ skipwhite skipempty skipnl
+syn match tealFunctionName /\K\k*\(\.\K\k*\)*\(:\K\k*\)\?/ contained
 	\ nextgroup=tealFunctionGeneric,tealFunctionArgs
 	\ skipwhite skipempty skipnl
 syn region tealFunctionGeneric contained transparent


### PR DESCRIPTION
Rework some of the internals of the syntax groups for types. In particular experiment with programmatically generating the groups to describe types to allow for differentiating between a list of types, e.g.
```
local a, b, c: number, string, table
```
and single type annotations, which are present in function arguments
```
local function foo(a: number, b: string, c: table)
```
so that the comma is recognized as the argument separator rather than a separator in a list of types

This pr _should_ not change anything else, but if it does that is a bug.

Should close #14