### PR TITLE
Fix highlighting for `where` with generic records.

### DIFF
--- a/syntax/teal.vim
+++ b/syntax/teal.vim
@@ -284,7 +284,6 @@ syn region tealRecordGeneric contained transparent
 	\ start=/</ end=/>/
 	\ contains=tealGeneric
 	\ nextgroup=@tealRecordItem,tealInterfaceIs
-	\ skipwhite skipnl skipempty
 syn keyword tealRecordUserdata userdata contained
 	\ nextgroup=@tealRecordItem
 	\ skipwhite skipnl skipempty


### PR DESCRIPTION
This fixes the issue where the following is not highlighted correctly:

```teal
local record Foo<Bar> where self.foo == "bar"
    foo: string
end
```